### PR TITLE
Updated stripe-java to 1.32.1

### DIFF
--- a/StripeGrailsPlugin.groovy
+++ b/StripeGrailsPlugin.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 class StripeGrailsPlugin {
-    def version = "2.8"
+    def version = "2.9"
     def grailsVersion = "1.3.7 > *"
     def loadAfter = ['resources', 'jquery']
 

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -14,7 +14,7 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        compile 'com.stripe:stripe-java:1.17.0'
+        compile 'com.stripe:stripe-java:1.32.1'
     }
 
     plugins {


### PR DESCRIPTION
I updated to the latest version of the stripe-java SDK. There were some non-backwards compatible updates (especially affecting the Card object) in recent updates to the Stripe API.

Oddly, I find I now need to include the Gson jar in my Grails app's lib/ dir in order to use the API. Not sure if that's related to my change or not. 